### PR TITLE
Eliminar linea del borrado del spinner.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -14,7 +14,6 @@ page('/', function (ctx, next) {
   $tvShowsContainer.find('.tv-show').remove()
   if (!localStorage.shows) {
     getShows(function (shows) {
-      $tvShowsContainer.find('.loader').remove();
       localStorage.shows = JSON.stringify(shows);
       renderShows(shows);
     })


### PR DESCRIPTION
Podemos obviar esa linea debido a que si vamos al index.js del modulo render, podemos notar que antes de hacer la iteración de los shows existen la linea donde se elimina primeramente el spinner.
